### PR TITLE
chore(npm): adiciona o package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "rss-feed-emitter",
+  "version": "0.0.1",
+  "description": "Agregador de RSS que emite eventos a cada novo item publicado [Node.js] [ES6]",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/filipedeschamps/rss-feed-emitter.git"
+  },
+  "keywords": [
+    "rss",
+    "feed",
+    "emitter",
+    "aggregator",
+    "news",
+    "atom"
+  ],
+  "author": "Filipe Deschamps",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/filipedeschamps/rss-feed-emitter/issues"
+  },
+  "homepage": "https://github.com/filipedeschamps/rss-feed-emitter#readme"
+}


### PR DESCRIPTION
Esta primeira versão do package.json serve para reservar o nome
do pacote no npm e também servir de exemplo para o styleguide
de commits que utiliza o [AngularJS Commit Message Convensions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y)

Closes #1