### PR TITLE
feat(module): extende interface do TinyEmitter

### DIFF
--- a/src/rss-feed-emitter.js
+++ b/src/rss-feed-emitter.js
@@ -1,8 +1,19 @@
+'use strict';
+
 import TinyEmitter from 'tiny-emitter';
 
 class RssFeedEmitter extends TinyEmitter {
+
 	constructor() {
 		super();
+	}
+
+	add() {
+	
+	}
+
+	remove() {
+	
 	}
 
 }

--- a/test/rss-fee-emitter.spec.js
+++ b/test/rss-fee-emitter.spec.js
@@ -13,6 +13,22 @@ describe('RssFeedEmitter', () => {
 		it('deve retornar um objeto', () => {
 			expect(feeder).to.be.an('object');
 		});
+
+		it('#add deve ser uma função', () => {
+			expect(feeder.add).to.be.a('function');
+		});
+
+		it('#remove deve ser uma função', () => {
+			expect(feeder.remove).to.be.a('function');
+		});
+
+		it('#on deve ser uma função', () => {
+			expect(feeder.on).to.be.a('function');
+		});
+
+		it('#emit deve ser uma função', () => {
+			expect(feeder.emit).to.be.a('function');
+		});
 	})
 
 })


### PR DESCRIPTION
E cria os testes para se certificar que as interfaces `#add`, `#remove`,
`#on` e `#emit` existem garantindo que o módulo também é um event
emitter.