### PR TITLE
fix(destroy): limpa corretamente todos os setIntervals

### DIFF
--- a/src/rss-feed-emitter.js
+++ b/src/rss-feed-emitter.js
@@ -35,9 +35,10 @@ class RssFeedEmitter extends TinyEmitter {
 	}
 
 	destroy() {
-		this._feedList = this._feedList.filter( (feed) => {
+		for (let i = this._feedList.length -1; i >=0; i--) {
+			let feed = this._feedList[i];
 			this._removeFromFeedList(feed);
-		});
+		}
 	}
 
 
@@ -90,7 +91,7 @@ class RssFeedEmitter extends TinyEmitter {
 	}
 
 	_getFeedContent(feed) {
-		console.log('Getting content in rate of: ' + feed.refresh)
+		console.log(`Every ${feed.refresh} get ${feed.url}`);
 	}
 
 


### PR DESCRIPTION
Agora este método limpa devidamente todos os setIntervals cadastrados no
feed. Antes, ao iterar e deletar itens simultaneamente no array alterava
o índice e o loop se perdia, mantendo sempre o último item do array
intacto.

Closes #17
Closes #19