### PR TITLE
test(mocha): adiciona beforeEach e afterEach

### DIFF
--- a/test/rss-fee-emitter.spec.js
+++ b/test/rss-fee-emitter.spec.js
@@ -31,23 +31,26 @@ describe('RssFeedEmitter', () => {
 
 	describe('#add', () => {
 
+		let feeder;
+
+		beforeEach( () => {
+			feeder = new RssFeedEmitter();
+		})
+
 		it('deve ser uma função', () => {
 
-			let feeder = new RssFeedEmitter();
 			expect( feeder.add ).to.be.a('function');
 
 		});
 
 		it('deve retornar erro quando chamado sem objeto de configuração', () => {
 
-			let feeder = new RssFeedEmitter();
 			expect( () => feeder.add() ).to.throw(Error);
 
 		});
 
 		it('deve retornar erro quando objeto de configuração não possui "url"', () => {
 
-			let feeder = new RssFeedEmitter();
 			expect( () => {
 				feeder.add({
 					refresh: 60000
@@ -58,8 +61,6 @@ describe('RssFeedEmitter', () => {
 
 		it('deve retornar erro quando objeto de configuração possui "url" mas não é uma string', () => {
 
-			let feeder = new RssFeedEmitter();
-
 			expect( () => { 
 				feeder.add({
 					url: [1, 2, 3]
@@ -69,8 +70,6 @@ describe('RssFeedEmitter', () => {
 		});
 
 		it('deve retornar erro quando objeto de configuração possui "refresh" mas não um número', () => {
-
-			let feeder = new RssFeedEmitter();
 
 			expect( () => { 
 				feeder.add({
@@ -83,10 +82,8 @@ describe('RssFeedEmitter', () => {
 
 		it('deve adicionar corretamente feeds quando possuir somente "url"', () => {
 
-			let feeder = new RssFeedEmitter();
-
 			feeder.add({
-				url: 'http://www.nintendolife.com/feeds/latest',
+				url: 'http://www.nintendolife.com/feeds/reviews',
 			});
 
 			feeder.add({
@@ -101,10 +98,8 @@ describe('RssFeedEmitter', () => {
 
 		it('deve substituir a taxa de atualização padrão quando possuir "refresh"', () => {
 
-			let feeder = new RssFeedEmitter();
-
 			feeder.add({
-				url: 'http://www.nintendolife.com/feeds/latest',
+				url: 'http://www.nintendolife.com/feeds/comments',
 				refresh: 120000
 			});
 
@@ -114,10 +109,8 @@ describe('RssFeedEmitter', () => {
 
 		it('deve atualizar o feed quando "url" já existir na lista de feeds', () => {
 
-			let feeder = new RssFeedEmitter();
-
 			feeder.add({
-				url: 'http://www.nintendolife.com/feeds/latest',
+				url: 'http://www.nintendolife.com/feeds/forums',
 				refresh: 120000
 			});
 
@@ -125,7 +118,7 @@ describe('RssFeedEmitter', () => {
 			expect( feeder.list()[0] ).to.have.property('refresh', 120000);
 
 			feeder.add({
-				url: 'http://www.nintendolife.com/feeds/latest',
+				url: 'http://www.nintendolife.com/feeds/forums',
 				refresh: 240000 
 			});
 
@@ -134,20 +127,28 @@ describe('RssFeedEmitter', () => {
 
 		});
 
+		afterEach( () => {
+			feeder.destroy();
+		})
+
 	})
 
 	describe('#list', () => {
 
+		let feeder;
+
+		beforeEach( () => {
+			feeder = new RssFeedEmitter();
+		})
+
 		it('deve ser uma função', () => {
 
-			let feeder = new RssFeedEmitter();
 			expect( feeder.list ).to.be.a('function');
 
 		});
 
 		it('deve retornar um array em branco por default', () => {
 
-			let feeder = new RssFeedEmitter();
 			let list = feeder.list();
 
 			expect( list ).to.be.an('array');
@@ -158,15 +159,13 @@ describe('RssFeedEmitter', () => {
 
 		it('deve listar todos os feeds cadastrados', () => {
 
-			let feeder = new RssFeedEmitter();
-
 			feeder.add({
-				url: 'http://www.nintendolife.com/feeds/latest',
+				url: 'http://www.nintendolife.com/feeds/mario',
 				refresh: 2000
 			});
 
 			feeder.add({
-				url: 'http://www.nintendolife.com/feeds/news',
+				url: 'http://www.nintendolife.com/feeds/zelda',
 				refresh: 5000
 			});
 
@@ -174,14 +173,18 @@ describe('RssFeedEmitter', () => {
 
 			expect( list ).to.have.property('length', 2);
 
-			expect( list[0] ).to.have.property('url', 'http://www.nintendolife.com/feeds/latest');
+			expect( list[0] ).to.have.property('url', 'http://www.nintendolife.com/feeds/mario');
 			expect( list[0] ).to.have.property('refresh', 2000);
 			expect( list[0] ).to.have.property('setInterval');
 
-			expect( list[1] ).to.have.property('url', 'http://www.nintendolife.com/feeds/news');
+			expect( list[1] ).to.have.property('url', 'http://www.nintendolife.com/feeds/zelda');
 			expect( list[1] ).to.have.property('refresh', 5000);
 			expect( list[1] ).to.have.property('setInterval');
 
+		})
+
+		afterEach( () => {
+			feeder.destroy();
 		})
 
 	})
@@ -197,12 +200,12 @@ describe('RssFeedEmitter', () => {
 			let feeder = new RssFeedEmitter();
 
 			feeder.add({
-				url: 'http://www.nintendolife.com/feeds/latest',
+				url: 'http://www.nintendolife.com/feeds/link',
 				refresh: 2000
 			});
 
 			feeder.add({
-				url: 'http://www.nintendolife.com/feeds/news',
+				url: 'http://www.nintendolife.com/feeds/luigi',
 				refresh: 5000
 			});
 


### PR DESCRIPTION
Com isto, cada `it` ganha uma nova instância do feeder e é destruída em
seguida mantendo todos os specs realmente atômicos.