### PR TITLE
feat(module): rejeita Promise ao encontrar error no parse do feed

### DIFF
--- a/src/rss-feed-emitter.js
+++ b/src/rss-feed-emitter.js
@@ -127,6 +127,7 @@ class RssFeedEmitter extends TinyEmitter {
 				.then(this._identifyOnlyNewItems)
 				.then(this._populateItemsInFeed)
 				.catch((error) => {
+					console.log('Error in getContent() chain inside _createSetInterval()');
 					console.log(error.stack)
 				})
 		}
@@ -217,6 +218,10 @@ class RssFeedEmitter extends TinyEmitter {
 				}
 
 				return items;
+			});
+
+			feedparser.on('error', (error) => {
+				reject(error);
 			});
 
 


### PR DESCRIPTION
Agora quando o feedparser emite erro, o módulo corretamente rejeita a
Promise.

Closes #39