### PR TITLE
test(integration): create integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "Agregador de RSS que emite eventos a cada novo item publicado [Node.js] [ES6]",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register test/**/*.spec.js",
-    "test-watch": "mocha --watch --compilers js:babel-core/register test/**/*.spec.js"
+    "test": "npm run test-unit && npm run test-integration",
+    "test-watch": "mocha --watch --compilers js:babel-core/register test/**/*.spec.js",
+    "test-unit": "mocha --compilers js:babel-core/register test/unit/**/*.spec.js",
+    "test-unit-watch": "mocha --watch --compilers js:babel-core/register test/unit/**/*.spec.js",
+    "test-integration": "mocha --timeout 30000 --compilers js:babel-core/register test/integration/**/*.spec.js",
+    "test-integration-watch": "mocha --watch --timeout 30000 --compilers js:babel-core/register test/integration/**/*.spec.js"
   },
   "repository": {
     "type": "git",

--- a/test/integration/rss-feed-emitter.spec.js
+++ b/test/integration/rss-feed-emitter.spec.js
@@ -1,0 +1,246 @@
+'use strict';
+
+import chai from 'chai';
+import RssFeedEmitter from '../../src/rss-feed-emitter.js';
+
+let expect = chai.expect;
+
+describe('RssFeedEmitter (integration)', () => {
+
+	describe('#on', () => {
+
+		let feeder;
+
+		beforeEach( () => {
+			feeder = new RssFeedEmitter();
+		})
+
+		it('should emit items from "Nintendo Life"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'http://www.nintendolife.com/feeds/latest';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+		it('should emit items from "BBC News"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'http://feeds.bbci.co.uk/news/rss.xml';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+
+		it('should emit items from "Time"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'http://feeds.feedburner.com/time/topstories?format=xml';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+
+		it('should emit items from "Bloomberg"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'http://www.bloomberg.com/feed/podcast/etf-report.xml';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+
+		it('should emit items from "The Guardian"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'http://www.theguardian.com/world/rss';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+
+		it('should emit items from "The Huffington Post"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'http://feeds.huffingtonpost.com/c/35496/f/677045/index.rss';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+
+		it('should emit items from "The New York Times"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'http://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+
+		it('should emit items from "Reddit"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'https://www.reddit.com/.rss';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+		it('should emit items from "CNN"', (done) => {
+
+			let itemsReceived = [];
+			let feedUrl = 'http://rss.cnn.com/rss/edition.rss';
+
+			feeder.add({
+				url: feedUrl,
+				refresh: 60000
+			});
+
+			feeder.on('new-item', (item) => {
+				itemsReceived.push(item);
+				expect(item.title).to.be.a('string');
+				expect(item.description).to.be.a('string');
+				expect(item.date).to.be.a('date');
+				expect(item.meta).to.have.property('link', feedUrl);
+
+				if (itemsReceived.length === 1) {
+					done();
+				}
+			})
+
+		});
+
+		afterEach( () => {
+			feeder.destroy();
+		})
+
+	})
+
+})

--- a/test/unit/rss-feed-emitter.spec.js
+++ b/test/unit/rss-feed-emitter.spec.js
@@ -7,7 +7,7 @@ import * as _ from 'lodash';
 
 let expect = chai.expect;
 
-describe('RssFeedEmitter', () => {
+describe('RssFeedEmitter (unit)', () => {
 
 	describe('quando instanciado', () => {
 


### PR DESCRIPTION
This is a simple test that certifies if feeder is able to emit
`new-item` with the correct interface. Probably could be stressed a lot
more.

Closes #44