### PR TITLE
Updated dependency "request", due to CVE-2018-1000620

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "bluebird": "3.0.5",
     "feedparser": "1.1.4",
-    "request": "2.83.0",
+    "request": "2.88.0",
     "lodash": "4.17.5",
     "tiny-emitter": "1.0.1"
   }


### PR DESCRIPTION
Hello,

My tool, [AlertHub](https://github.com/Ardakilic/alerthub/) depends on this package. First of all, thank you for making this available for us all!

I've realized there's been a security issue with one of the dependencies, `request`:

https://nvd.nist.gov/vuln/detail/CVE-2018-1000620

```
alerthub@1.1.0 /Users/arda/projects/alerthub git:(master) ✗ npm ls cryptiles
└─┬ rss-feed-emitter@2.0.0
  └─┬ request@2.83.0
    └─┬ hawk@6.0.2
      └── cryptiles@3.1.4
```

This pull request aims to resolve this issue by updating the dependency.

Also, there are other vulnerabilities when you run `npm audit`.

I'd appreciate if this'd be considered.

Thanks in advance,