### PR TITLE
fix: re-add nyc wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test/**/*.spec.js"
   },
   "scripts": {
-    "test": "npx mocha \"test/**/*.spec.js\" --exit",
+    "test": "npx nyc npx mocha \"test/**/*.spec.js\" --exit",
     "coverage": "npm test && npx nyc report --reporter=text-lcov | npx coveralls",
     "lint": "npx eslint src/ test/",
     "lint:fix": "npx eslint src/ test/ --fix"


### PR DESCRIPTION
I re-added the nyc wrapping call, which fixes the coverage step (on my travis build, at least)

https://travis-ci.com/TobiTenno/rss-feed-emitter/builds/144546100