### PR TITLE
feat: implement array urls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: node_js
+os: linux
+dist: bionic
+cache: npm
 node_js:
-  - "node"
-  - "stable"
-  - "11"
-  - "10"
-  - "9"
-  - "8"
+  - node
+  - lts/*
+  - stable
+  - 13
+  - 12
+  - 11
+  - 10
+  - 9
+  - 8
 
 stages:
   - lint
@@ -16,7 +22,5 @@ jobs:
   include:
     - stage: lint
       script: npm run lint
-    - stage: test
-      script: npm test
     - stage: coverage
       script: npm run coverage

--- a/README.md
+++ b/README.md
@@ -65,20 +65,20 @@ $ npm install rss-feed-emitter
 
 ### Creating an instance
 
-``` js
-let RssFeedEmitter = require('rss-feed-emitter');
-let feeder = new RssFeedEmitter();
+```js
+const RssFeedEmitter = require('rss-feed-emitter');
+const feeder = new RssFeedEmitter();
 ```
 
 #### Changing the user agent for requests
 
-``` js
-let feeder = new RssFeedEmitter({ userAgent: 'Your UA string' });
+```js
+const feeder = new RssFeedEmitter({ userAgent: 'Your UA string' });
 ```
 
 ### Adding feeds
 
-``` js
+```js
 feeder.add({
   url: 'http://www.nintendolife.com/feeds/news',
   refresh: 2000
@@ -87,21 +87,67 @@ feeder.add({
 
 > Default refresh value is 60 seconds
 
+You can also add multiple at once by either providing an array of urls for the `url` field:
+```js
+feeder.add({
+  url: ['http://www.nintendolife.com/feeds/news', 'http://feeds.bbci.co.uk/news/rss.xml' ],
+  refresh: 2000
+});
+```
+
+or by passing multiple configs:
+```js
+feeder.add({
+  url: 'http://www.nintendolife.com/feeds/news',
+  refresh: 2000
+}, {
+  url: 'http://feeds.bbci.co.uk/news/rss.xml',
+  refresh: 5000
+});
+```
 
 ### Listening to new items
 
-``` js
+```js
 feeder.on('new-item', function(item) {
   console.log(item);
 })
 ```
 
+you can also override the default `'new-item'` event name with a new value of your choice by providing the event name in the feed config.
+```js
+feeder.add({
+  url: 'http://www.nintendolife.com/feeds/news',
+  refresh: 2000,
+  eventName: 'nintendo'
+});
 
-### Listing all feeds in the instance
-``` js
-feeder.list();
+feeder.on('nintendo', function(item) {
+  console.log(item);
+});
 ```
 
+### Ignoring the first load of items
+```js
+const feeder = new RssFeedEmitter({ skipFirstLoad: true });
+
+feeder.add({
+  url: 'http://www.nintendolife.com/feeds/news',
+  refresh: 2000,
+  eventName: 'nintendo'
+});
+
+// this item will only be from the new items, not from old items.
+feeder.on('nintendo', function(item) {
+  console.log(item);
+});
+```
+
+### Listing all feeds in the instance
+The list is now an ES6 getter to make the field a bit more plain to access.
+```js
+feeder.list;
+```
 
 ### Removing a single feed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1439,14 +1439,15 @@
       "dev": true
     },
     "nock": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
-      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.2.tgz",
+      "integrity": "sha512-7swr5bL1xBZ5FctyubjxEVySXOSebyqcL7Vy1bx1nS9IUqQWj81cmKjVKJLr8fHhtzI1MV8nyCdENA/cGcY1+Q==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.13",
+        "mkdirp": "^0.5.0",
         "propagate": "^2.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1397,12 +1397,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1410,6 +1404,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -1437,15 +1439,14 @@
       "dev": true
     },
     "nock": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.2.tgz",
-      "integrity": "sha512-7swr5bL1xBZ5FctyubjxEVySXOSebyqcL7Vy1bx1nS9IUqQWj81cmKjVKJLr8fHhtzI1MV8nyCdENA/cGcY1+Q==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.13",
-        "mkdirp": "^0.5.0",
         "propagate": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.20.0",
-    "nock": "^11.7.2"
+    "nock": "^12.0.3"
   },
   "dependencies": {
     "atom-ui-reporter": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.20.0",
-    "nock": "^12.0.3"
+    "nock": "^11.7.2"
   },
   "dependencies": {
     "atom-ui-reporter": "0.0.1",

--- a/src/Feed.js
+++ b/src/Feed.js
@@ -34,6 +34,7 @@ class Feed {
       url: this.url,
       refresh: this.refresh,
       userAgent: this.userAgent,
+      eventName: this.eventName,
     } = data);
 
     if (!this.items) {
@@ -56,6 +57,10 @@ class Feed {
      */
     if (!this.userAgent) {
       this.userAgent = DEFAULT_UA;
+    }
+
+    if (!this.eventName) {
+      this.eventName = 'new-item';
     }
   }
 

--- a/src/FeedEmitter.js
+++ b/src/FeedEmitter.js
@@ -26,8 +26,8 @@ const checkFeed = (feed) => {
 };
 
 const checkUrl = (feed) => {
-  if (!feed.url || typeof feed.url !== 'string') {
-    throw new FeedError('Your configuration object should have an "url" key with a string value', 'type_error');
+  if (!feed.url || !(typeof feed.url === 'string' || Array.isArray(feed.url))) {
+    throw new FeedError('Your configuration object should have an "url" key with a string or array value', 'type_error');
   }
 };
 
@@ -76,6 +76,14 @@ class FeedEmitter extends EventEmitter {
     this.userAgent = options.userAgent;
   }
 
+
+  /**
+   * UserFeedConfig typedef
+   * @typedef {Object} UserFeedConfig
+   * @property {(string|string[])} url Url string or string array. Cannot be null or empty
+   * @property {Number} refresh Refresh cycle duration for the feed.
+   */
+
   /**
    * ADD
    * The #add method is one of the main ones. Basically it
@@ -84,15 +92,26 @@ class FeedEmitter extends EventEmitter {
    *    url: "http://www.nintendolife.com/feeds/news",
    *    refresh: 2000
    *  }
-   * @param {Object} userFeedConfig user feed config
+   * @param {UserFeedConfig} userFeedConfig user feed config
+   * @returns {Feed[]}
    */
-
   add(userFeedConfig) {
     FeedEmitter.validateFeedObject(userFeedConfig, this.userAgent);
+
+    if (Array.isArray(userFeedConfig.url)) {
+      userFeedConfig.url.forEach((url) => {
+        this.add({
+          ...userFeedConfig,
+          url,
+        });
+      });
+      return this.feedList;
+    }
 
     const feed = new Feed(userFeedConfig);
 
     this.addOrUpdateFeedList(feed);
+
     return this.feedList;
   }
 

--- a/src/FeedEmitter.js
+++ b/src/FeedEmitter.js
@@ -62,7 +62,7 @@ class FeedEmitter extends EventEmitter {
    * we create a new instance of this "Class".
    * @param {Object} [options={ userAgent: defaultUA }] [description]
    */
-  constructor(options = { userAgent: DEFAULT_UA }) {
+  constructor(options = { userAgent: DEFAULT_UA, skipFirstLoad: false }) {
     super();
 
     this.feedList = [];
@@ -74,6 +74,12 @@ class FeedEmitter extends EventEmitter {
      * @type {string}
      */
     this.userAgent = options.userAgent;
+
+    /**
+     * Whether or not to skip the normal emit event on first load
+     * @type {boolean}
+     */
+    this.skipFirstLoad = options.skipFirstLoad;
   }
 
 
@@ -182,7 +188,7 @@ class FeedEmitter extends EventEmitter {
    */
   createSetInterval(feed) {
     const feedManager = new FeedManager(this, feed);
-    feedManager.getContent();
+    feedManager.getContent(true);
     return setInterval(feedManager.getContent.bind(feedManager), feed.refresh);
   }
 

--- a/src/FeedEmitter.js
+++ b/src/FeedEmitter.js
@@ -92,23 +92,30 @@ class FeedEmitter extends EventEmitter {
    *    url: "http://www.nintendolife.com/feeds/news",
    *    refresh: 2000
    *  }
-   * @param {UserFeedConfig} userFeedConfig user feed config
+   * @param {UserFeedConfig[]} userFeedConfig user feed config
    * @returns {Feed[]}
    */
-  add(userFeedConfig) {
-    FeedEmitter.validateFeedObject(userFeedConfig, this.userAgent);
+  add(...userFeedConfig) {
+    if (userFeedConfig.length > 1) {
+      userFeedConfig.forEach((f) => this.add(f));
+      return this.feedList;
+    }
 
-    if (Array.isArray(userFeedConfig.url)) {
-      userFeedConfig.url.forEach((url) => {
+    const config = userFeedConfig[0];
+
+    FeedEmitter.validateFeedObject(config, this.userAgent);
+
+    if (Array.isArray(config.url)) {
+      config.url.forEach((url) => {
         this.add({
-          ...userFeedConfig,
+          ...config,
           url,
         });
       });
       return this.feedList;
     }
 
-    const feed = new Feed(userFeedConfig);
+    const feed = new Feed(config);
 
     this.addOrUpdateFeedList(feed);
 

--- a/src/FeedManager.js
+++ b/src/FeedManager.js
@@ -38,11 +38,14 @@ class FeedManager {
    * Now that we have all the new items, add them to the
    feed item list.
    * @param  {Object} data data to mutate
+   * @param {boolean} firstload Whether or not this is the first laod
    */
-  populateNewItemsInFeed(data) {
+  populateNewItemsInFeed(data, firstload) {
     data.newItems.forEach((item) => {
       this.feed.addItem(item);
-      this.instance.emit(this.feed.eventName, item);
+      if (!(firstload && this.instance.skipFirstLoad)) {
+        this.instance.emit(this.feed.eventName, item);
+      }
     });
   }
 
@@ -50,7 +53,7 @@ class FeedManager {
     this.instance.emit('error', error);
   }
 
-  async getContent() {
+  async getContent(firstload) {
     this.feed.fetchData()
       .then((items) => {
         const data = {
@@ -61,6 +64,9 @@ class FeedManager {
         this.sortItemsByDate(data);
         this.identifyNewItems(data);
         this.populateNewItemsInFeed(data);
+        if (firstload && !this.instance.skipFirstLoad) {
+          this.instance.emit(`initial-load:${this.feed.url}`, { url: this.feed.url, items: this.feed.items });
+        }
       })
       .catch(this.onError.bind(this));
   }

--- a/src/FeedManager.js
+++ b/src/FeedManager.js
@@ -9,6 +9,10 @@ class FeedManager {
   constructor(emitter, feed) {
     this.instance = emitter;
     this.feed = feed;
+
+    this.feed.handler = {
+      handle: this.onError.bind(this),
+    };
   }
 
   /**

--- a/src/FeedManager.js
+++ b/src/FeedManager.js
@@ -42,7 +42,7 @@ class FeedManager {
   populateNewItemsInFeed(data) {
     data.newItems.forEach((item) => {
       this.feed.addItem(item);
-      this.instance.emit('new-item', item);
+      this.instance.emit(this.feed.eventName, item);
     });
   }
 

--- a/test/integration/rss-feed-emitter.spec.js
+++ b/test/integration/rss-feed-emitter.spec.js
@@ -43,6 +43,10 @@ const feeds = [
     name: 'Milliyet Gazetesi',
     url: 'http://www.milliyet.com.tr/rss/rssNew/gundemRss.xml',
   },
+  {
+    name: 'CNN',
+    url: 'http://rss.cnn.com/rss/edition.rss',
+  },
 ];
 
 
@@ -64,8 +68,11 @@ describe('RssFeedEmitter (integration)', () => {
           if (!doneski) {
             doneski = true;
             expect(item.title).to.be.a('string');
-            expect(item.description).to.be.a('string');
-            expect(item.date).to.be.a('date');
+            if (name !== 'CNN') {
+              // apparently cnn doesn't support some nor
+              expect(item.description).to.be.a('string');
+              expect(item.date).to.be.a('date');
+            }
             expect(item.meta).to.have.property('link', url);
 
             done();

--- a/test/integration/rss-feed-emitter.spec.js
+++ b/test/integration/rss-feed-emitter.spec.js
@@ -6,7 +6,7 @@ const RssFeedEmitter = require('../../src/FeedEmitter');
 const { expect } = chai;
 
 const expectedlength = 1;
-const refresh = 100;
+const refresh = 1000;
 
 process.env.NOCK_OFF = true;
 
@@ -21,7 +21,7 @@ const feeds = [
   },
   {
     name: 'Time',
-    url: 'http://feeds.feedburner.com/time/topstories?format=xml',
+    url: 'http://feeds.feedburner.com/time/topstories?fmt=xml',
   },
   {
     name: 'The Guardian',
@@ -43,35 +43,33 @@ const feeds = [
     name: 'Milliyet Gazetesi',
     url: 'http://www.milliyet.com.tr/rss/rssNew/gundemRss.xml',
   },
-  {
-    name: 'CNN',
-    url: 'http://rss.cnn.com/rss/edition.rss',
-  },
 ];
 
 
-// I've had issues with these, but if someone wants to rewrite it fully, they're welcome to.
-// I can get them to notify in a tester, but not in here, sadly.
-xdescribe('RssFeedEmitter (integration)', () => {
+describe('RssFeedEmitter (integration)', () => {
   describe('#on', () => {
     let feeder;
 
     beforeEach(() => { feeder = new RssFeedEmitter(); });
 
+    afterEach(() => { feeder.destroy(); });
+
     feeds.forEach(({ name, url }) => {
       it(`should emit items from "${name}"`, (done) => {
-        const itemsReceived = [];
-
         feeder.add({ url, refresh });
 
+        let doneski = false;
+
         feeder.on('new-item', (item) => {
-          itemsReceived.push(item);
-          expect(item.title).to.be.a('string');
-          expect(item.description).to.be.a('string');
-          expect(item.date).to.be.a('date');
-          expect(item.meta).to.have.property('link', url);
-          expect(itemsReceived.length).to.be(expectedlength);
-          done();
+          if (!doneski) {
+            doneski = true;
+            expect(item.title).to.be.a('string');
+            expect(item.description).to.be.a('string');
+            expect(item.date).to.be.a('date');
+            expect(item.meta).to.have.property('link', url);
+
+            done();
+          }
         });
       });
     });

--- a/test/unit/rss-feed-emitter.spec.js
+++ b/test/unit/rss-feed-emitter.spec.js
@@ -262,7 +262,7 @@ describe('RssFeedEmitter (unit)', () => {
 
       feeder.add({
         url: 'https://www.nintendolife.com/feeds/latest',
-        refresh: 20,
+        refresh: 100,
       });
 
       const maxItemsReceived = 69;


### PR DESCRIPTION
closes #156
closes #163 
closes #164 (done a while ago, but marking here to make it close automagically)
closes #170 
closes #171 
work back towards 100% coverage
fix issues with integration specs
support adding multiple feeds at once in a few different ways...
```js
const Feeder = require('rss-feed-emitter');

const feeder = new Feeder();
feeder.add({
  url: ['https://github.com', 'https://npmjs.org'],
}, {
  url: 'https://microsoft.com'
});
```