### PR TITLE
Fixing FeedEmitter missing "eventName" property type

### DIFF
--- a/src/FeedEmitter.js
+++ b/src/FeedEmitter.js
@@ -102,6 +102,7 @@ class FeedEmitter extends EventEmitter {
    * @typedef {Object} UserFeedConfig
    * @property {(string|string[])} url Url string or string array. Cannot be null or empty
    * @property {Number} refresh Refresh cycle duration for the feed.
+   * @property {string} [eventName] Event name for a new feed item. Default "new-item". 
    */
 
   /**

--- a/src/FeedEmitter.js
+++ b/src/FeedEmitter.js
@@ -102,7 +102,7 @@ class FeedEmitter extends EventEmitter {
    * @typedef {Object} UserFeedConfig
    * @property {(string|string[])} url Url string or string array. Cannot be null or empty
    * @property {Number} refresh Refresh cycle duration for the feed.
-   * @property {string} [eventName] Event name for a new feed item. Default "new-item". 
+   * @property {string} [eventName] Event name for a new feed item. Default "new-item".
    */
 
   /**


### PR DESCRIPTION
FeedEmitter was missing `eventName` property type which was causing issue while working with Typescript.
Optional `eventName` has been added.